### PR TITLE
fixed build.gradle for the environment w/o vars 'sonatype.username' and 'sonatype.password'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ signing {
   sign configurations.archives
 }
 
+if (project.hasProperty('sonatype.username') && project.hasProperty('sonatype.password'))
 uploadArchives {
   repositories {
     mavenDeployer {


### PR DESCRIPTION
Problem: when compiling in the environment where variables 'sonatype.username' and 'sonatype.password' are not defined, gradle returns an error: 

FAILURE: Build failed with an exception.
- Where:
  Build file '/home/ahi/Projects/gradle-retrolambda/build.gradle' line: 52
- What went wrong:
  A problem occurred evaluating root project 'gradle-retrolambda'.
  > Could not find property 'sonatype.username' on root project 'gradle-retrolambda'.

This fix protects against this error, effectively allowing to compile on "vanilla" machines.
