### PR TITLE
Automatically grab Java home from the JRE location in System.properties ...

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
@@ -19,6 +19,8 @@ package me.tatarka
 import org.gradle.api.JavaVersion
 import org.gradle.api.ProjectConfigurationException
 
+import java.util.regex.Pattern
+
 import static me.tatarka.RetrolambdaPlugin.javaVersionToBytecode
 
 /**
@@ -32,6 +34,7 @@ public class RetrolambdaExtension {
     int bytecodeVersion = 50
     List<String> excludes = []
     List<String> includes = []
+    String javaHomeProp = System.properties.'java.home'.toString().split(Pattern.quote(System.properties.'file.separator'.toString() + "jre"))[0]
     boolean isOnJava8 = System.properties.'java.version'.startsWith('1.8')
 
     private String jdk = null
@@ -112,7 +115,11 @@ public class RetrolambdaExtension {
 
     private String findJdk() {
         if (isOnJava8) {
-            return System.getenv("JAVA_HOME")
+            if (javaHomeProp) {
+                return javaHomeProp
+            } else {
+                return System.getenv("JAVA_HOME")
+            }
         } else {
             return System.getenv("JAVA8_HOME")
         }


### PR DESCRIPTION
...if set.

Android Studio sets this in the JDK Location box in its Project Settings, and does not use JAVA_HOME. Android Studio then passes this location to Gradle. This patch enables retrolambda to read this setting, freeing the user from having to set a JAVA_HOME environment variable, which is the current configuration suggestion.

Tested this with my Android Studio and it works perfectly! With my patched version of retrolambda, I can use lambdas in my Android project **WITHOUT** JAVA_HOME or JAVA8_HOME defined and **WITHOUT** the following configuration block:

```
retrolambda {
    jdk System.getenv("JAVA8_HOME")
    oldJdk System.getenv("JAVA7_HOME")
    javaVersion JavaVersion.VERSION_1_7
}
```
