### PR TITLE
Fix string index out of range issue if java.home path does not have the jre suffix

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
@@ -138,7 +138,13 @@ public class RetrolambdaExtension {
     private String findCurrentJdk() {
         String javaHomeProp = System.properties.'java.home'
         if (javaHomeProp) {
-            return javaHomeProp.substring(0, javaHomeProp.lastIndexOf("${File.separator}jre"))
+            int jreIndex = javaHomeProp.lastIndexOf("${File.separator}jre")
+            if (jreIndex != -1) {
+                return javaHomeProp.substring(0, jreIndex)
+            }
+            else {
+                return javaHomeProp
+            }
         } else {
             return System.getenv("JAVA_HOME")
         }


### PR DESCRIPTION
I'm using gradle-retrolambda on Mac OS X 10.9 with JDK 8u11 x64 and the default java.home path does not end with /jre. I made a check to only remove /jre if found, otherwise just take the path as is. This fixes the string out of range -1 error I was getting when building.
