### PR TITLE
specifically state which build.gradle file to edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 
 1. Download [jdk8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
-2. Add the following to your build.gradle
+2. Add the following to your **Project** build.gradle
 
    ```groovy
    buildscript {
@@ -30,7 +30,11 @@ Usage
    repositories {
       mavenCentral()
    }
+   ```
 
+   And the following to your **Module** build.gradle
+
+   ```groovy
    apply plugin: 'com.android.application' //or apply plugin: 'java'
    apply plugin: 'retrolambda'
    ```
@@ -91,7 +95,7 @@ dependencies {
 
 Android Studio Setup
 --------------------
-Add these lines to you `build.gradle` to inform the IDE of the language level.
+Add these lines to your `build.gradle` to inform the IDE of the language level.
 
 ```groovy
 android {


### PR DESCRIPTION
Readme is already good, but it may easily confuse which `build.gradle` file to use. This small edit could void this problem.
