### PR TITLE
fix isIncluded test

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
@@ -113,8 +113,8 @@ public class RetrolambdaExtension {
 
     public boolean isIncluded(String name) {
         if (includes.isEmpty() && excludes.isEmpty()) return true
-        if (excludes.isEmpty() && excludes.contains(name)) return false;
-        if (includes.isEmpty() && !includes.contains(name)) return false;
+        if (excludes.isEmpty() && !includes.contains(name)) return false;
+        if (includes.isEmpty() && excludes.contains(name)) return false;
         return true
     }
 


### PR DESCRIPTION
There is a bug when setting either exclude or include on the extension. Specifying include will still include all source sets / variants. On the other hand, specifying exclude will include none of the source sets / variants, even the ones that weren't set in the exclude list.

As it was really simple to fix, I already created a pull request for this.