### PR TITLE
Fix of #134 - setting retrolambdaTask.enabled dynamically

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaPluginGroovy.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPluginGroovy.groovy
@@ -18,6 +18,7 @@ package me.tatarka
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.Task
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
 
@@ -51,7 +52,12 @@ public class RetrolambdaPluginGroovy implements Plugin<Project> {
                         classpath = set.compileClasspath + project.files(newOutputDir)
                         javaVersion = project.retrolambda.javaVersion
                         jvmArgs = project.retrolambda.jvmArgs
-                        enabled = !set.allJava.isEmpty()
+                    }
+
+                    project.gradle.taskGraph.beforeTask { Task task
+                        if (task == retrolambdaTask) {
+                            retrolambdaTask.setEnabled(!set.allJava.isEmpty())
+                        }
                     }
 
                     project.tasks.findByName(set.classesTaskName).dependsOn(retrolambdaTask)

--- a/src/main/groovy/me/tatarka/RetrolambdaPluginJava.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPluginJava.groovy
@@ -49,7 +49,7 @@ public class RetrolambdaPluginJava implements Plugin<Project> {
                         classpath = set.compileClasspath + project.files(newOutputDir)
                         javaVersion = project.retrolambda.javaVersion
                         jvmArgs = project.retrolambda.jvmArgs
-                        enabled = !set.allJava.isEmpty()
+                        enabled = true//!set.allJava.isEmpty()
                     }
 
                     project.tasks.findByName(set.classesTaskName).dependsOn(retrolambdaTask)

--- a/src/main/groovy/me/tatarka/RetrolambdaPluginJava.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPluginJava.groovy
@@ -18,6 +18,7 @@ package me.tatarka
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
+import org.gradle.api.Task
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.JavaCompile
 
@@ -49,7 +50,12 @@ public class RetrolambdaPluginJava implements Plugin<Project> {
                         classpath = set.compileClasspath + project.files(newOutputDir)
                         javaVersion = project.retrolambda.javaVersion
                         jvmArgs = project.retrolambda.jvmArgs
-                        enabled = true//!set.allJava.isEmpty()
+                    }
+
+                    project.gradle.taskGraph.beforeTask { Task task ->
+                        if (task == retrolambdaTask) {
+                            retrolambdaTask.setEnabled(!set.allJava.isEmpty())
+                        }
                     }
 
                     project.tasks.findByName(set.classesTaskName).dependsOn(retrolambdaTask)


### PR DESCRIPTION
When code generation tasks, which change `sourceSet` during the execution are involved we cannot statically set `enabled` flag during retrolambda task creation. As a quick patch I suggest to leave it always enabled. In the body of the task itself it can check whether the sourceSet is empty and thus skip an execution