### PR TITLE
Fix typo in v3.2.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Fixed long builds times on large projects due to https://issues.gradle.org/browse/GRADLE-3283.
 Note: Running the retrolambda task directly will no longer work, you must run the relevant java
 compile task instead.
-- Bumped default retrolambda version to `1.0.6`.
+- Bumped default retrolambda version to `2.0.6`.
 
 #### 3.2.2
 - Fixed wrongly deleting lambda classes where the related class is a prefix of the one that actually


### PR DESCRIPTION
Default retrolambda version is now `2.0.6`, not `1.0.6`.