### PR TITLE
Use includedFilesFile parameter

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaTask.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaTask.groovy
@@ -93,7 +93,15 @@ class RetrolambdaTask extends DefaultTask {
                 }
 
                 if (inputs.incremental && retrolambda.incremental) {
-                    jvmArgs += "-Dretrolambda.includedFiles=${changes*.file.join(File.pathSeparator)}"
+                    def includedFiles = changes*.file.join("\n");
+                    def includedFile = File.createTempFile("inc-", ".list");
+
+                    includedFile.withWriter('UTF-8') { writer ->
+                        writer.write(includedFiles)
+                    }
+                    jvmArgs += "-Dretrolambda.includedFilesFile=${includedFile.getAbsolutePath()}"
+
+                    includedFile.deleteOnExit();
                 }
                 
                 if (retrolambda.defaultMethods) {


### PR DESCRIPTION
```
 retrolambda.includedFilesFile (alternative)
      File listing the files to process, instead of processing all files.
      Alternative to retrolambda.includedFiles for avoiding the command line
      length limit. The file must list one file per line with UTF-8 encoding.
```
Since Retrolambda 2.1.0 (2015-12-19)

What else should be done? 