### PR TITLE
fixed execution retrolambda task within unitTest;

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
@@ -123,7 +123,8 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
         }
 
         JavaCompile compileUnitTest = (JavaCompile) project.tasks.find { task -> 
-            task.name.startsWith("compile${variant.capitalize()}UnitTestJava") 
+            task.name.startsWith("compile${variant.capitalize()}UnitTestJava") ||
+            task.name.startsWith("compile${variant.capitalize()}UnitTestJavaWithJavac")
         }
         if (compileUnitTest) {
             configureUnitTestTask(project, variant, compileUnitTest)

--- a/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
@@ -52,6 +52,9 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
             android.testVariants.all { TestVariant variant ->
                 configureCompileJavaTask(project, variant.name, variant.javaCompile)
             }
+            android.unitTestVariants.all { UnitTestVariant variant ->
+                configureUnitTestTask(project, variant.name, variant.javaCompile)
+            }
         } else {
             def android = project.extensions.getByType(AppExtension)
             android.applicationVariants.all { BaseVariant variant ->
@@ -59,6 +62,9 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
             }
             android.testVariants.all { TestVariant variant ->
                 configureCompileJavaTask(project, variant.name, variant.javaCompile)
+            }
+            android.unitTestVariants.all { UnitTestVariant variant ->
+                configureUnitTestTask(project, variant.name, variant.javaCompile)
             }
         }
     }
@@ -120,14 +126,6 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
         if (extractAnnotations) {
             extractAnnotations.deleteAllActions()
             project.logger.warn("$extractAnnotations.name is incompatible with java 8 sources and has been disabled.")
-        }
-
-        JavaCompile compileUnitTest = (JavaCompile) project.tasks.find { task -> 
-            task.name.startsWith("compile${variant.capitalize()}UnitTestJava") ||
-            task.name.startsWith("compile${variant.capitalize()}UnitTestJavaWithJavac")
-        }
-        if (compileUnitTest) {
-            configureUnitTestTask(project, variant, compileUnitTest)
         }
     }
 


### PR DESCRIPTION
The problem is:
- RL overrides java destination path
- but does not execute itself to process bytecode
- not consistency bytecode passes to dexTransform within apk creation