### PR TITLE
Use the _dirName_ of a variant as the id of a JavaCompile task.

### DIFF
--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
@@ -87,7 +87,7 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
             ensureCompileOnJava8(retrolambda, javaCompileTask)
         }
 
-        transform.putJavaCompileTask(variant.flavorName, variant.buildType.name, javaCompileTask)
+        transform.putJavaCompileTask(variant.dirName, javaCompileTask)
 
         def extractAnnotations = project.tasks.findByName("extract${variant.name.capitalize()}Annotations")
         if (extractAnnotations) {


### PR DESCRIPTION
Using build flavor and type alone does not distinguish between test
and non-test variants. Retrolambda can fail to transform a test
variant if it has additional dependencies.

The dirName of a variant is guaranteed to be unique. Build variant
deduction from an input path can now be done by subpath matching.