### PR TITLE
Update Retrolambda dependency to latest.

### DIFF
--- a/src/main/groovy/me/tatarka/RetrolambdaPlugin.groovy
+++ b/src/main/groovy/me/tatarka/RetrolambdaPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.plugins.JavaPlugin
  * To change this template use File | Settings | File Templates.
  */
 public class RetrolambdaPlugin implements Plugin<Project> {
-    protected static def retrolambdaCompile = "net.orfjackal.retrolambda:retrolambda:2.1.0"
+    protected static def retrolambdaCompile = "net.orfjackal.retrolambda:retrolambda:2.3.0"
 
     @Override
     void apply(Project project) {


### PR DESCRIPTION
This saves 2-4 methods per lambda in generated code.

I realize you can set this manually using the `retrolambdaConfig` configuration, but I suspect 95% of users of this plugin are not doing that.