### PR TITLE
Reenable extractAnnotations task

### DIFF
--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPluginAndroid.groovy
@@ -87,12 +87,6 @@ public class RetrolambdaPluginAndroid implements Plugin<Project> {
         }
 
         transform.putJavaCompileTask(variant.dirName, javaCompileTask)
-
-        def extractAnnotations = project.tasks.findByName("extract${RetrolambdaUtil.capitalize(variant.name)}Annotations")
-        if (extractAnnotations) {
-            extractAnnotations.deleteAllActions()
-            project.logger.warn("$extractAnnotations.name is incompatible with java 8 sources and has been disabled.")
-        }
     }
 
     private

--- a/sample-android-app/src/main/java/me/tatarka/retrolambda/sample/app/MyModule.java
+++ b/sample-android-app/src/main/java/me/tatarka/retrolambda/sample/app/MyModule.java
@@ -24,6 +24,6 @@ public class MyModule {
 
     @Provides
     public me.tatarka.retrolambda.sample.lib.Function provideLibHello() {
-        return Lib.getHello();
+        return Lib.getHello(Lib.MODE_A);
     }
 }

--- a/sample-android-app/src/test/java/me/tatarka/retrolambda/sample/app/test/FunctionTest.java
+++ b/sample-android-app/src/test/java/me/tatarka/retrolambda/sample/app/test/FunctionTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnit4.class)
 public class FunctionTest {
     MyModule module = new MyModule();
-    
+
     @Test
     public void testGetHello() {
         Resources res = mock(Resources.class);
@@ -30,9 +30,9 @@ public class FunctionTest {
 
     @Test
     public void testGetHelloLib() {
-        assertThat(module.provideLibHello().run()).isEqualTo("Hello, Retrolambda (from lib)!");
+        assertThat(module.provideLibHello().run()).isEqualTo("Hello, Retrolambda (from lib, mode a)!");
     }
-    
+
     @Test
     public void testLambdaInTest() {
         ResFunction lambda = (res) -> "test";

--- a/sample-android-lib/src/main/java/me/tatarka/retrolambda/sample/lib/Lib.java
+++ b/sample-android-lib/src/main/java/me/tatarka/retrolambda/sample/lib/Lib.java
@@ -1,10 +1,27 @@
 package me.tatarka.retrolambda.sample.lib;
 
+import android.support.annotation.IntDef;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Created by evan on 3/29/15.
  */
 public class Lib {
-    public static Function getHello(){
-        return () -> "Hello, Retrolambda (from lib)!";
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({MODE_A, MODE_B})
+    public @interface Mode {}
+
+    public static final int MODE_A = 1;
+    public static final int MODE_B = 2;
+
+
+    public static Function getHello(@Mode int mode) {
+        if (mode == MODE_A) {
+            return () -> "Hello, Retrolambda (from lib, mode a)!";
+        } else {
+            return () -> "Hello, Retrolambda (from lib, mode b)!";
+        }
     }
 }


### PR DESCRIPTION
Version 2.2.x of the Android Gradle plugin does support Java 8 sources so the task can be reenabled.

Related AOSP commits
https://android.googlesource.com/platform/tools/base/+/fcff10cf5c4c25e79f392d9b94313a1eb05d2265%5E%21/
https://android.googlesource.com/platform/tools/base/+/e28c5313619b14ff788f420a42b873ed8f2fe3d5%5E%21/

I've added an annotation that gets extracted to `sample-android-lib` to confirm that it works.  The task output can be found at `sample-android-lib/build/intermediates/annotations/debug/annotations.zip`.