### PR TITLE
Added support for new “quiet” config parameter introduced in Retrolambda 2.4.0

### DIFF
--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaExec.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaExec.groovy
@@ -42,6 +42,7 @@ class RetrolambdaExec {
     List<String> jvmArgs;
     int bytecodeVersion;
     boolean defaultMethods;
+    boolean quiet;
 
     private final Project project;
 
@@ -72,6 +73,7 @@ class RetrolambdaExec {
                     "-Dretrolambda.outputDir=$outputDir",
                     "-Dretrolambda.classpath=${path}",
                     "-Dretrolambda.bytecodeVersion=$bytecodeVersion",
+                    "-Dretrolambda.quiet=$quiet",
             ]
 
             VersionNumber retrolambdaVersion = retrolambdaVersion(retrolambdaConfig)

--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaExtension.groovy
@@ -31,6 +31,7 @@ public class RetrolambdaExtension {
     List<String> jvmArgs = []
     boolean incremental = true
     boolean defaultMethods = false
+    boolean quiet = false
     boolean isOnJava8 = (System.properties.'java.version' as String).startsWith('1.8')
 
     private Project project
@@ -49,6 +50,14 @@ public class RetrolambdaExtension {
 
     public void include(Object... e) {
         includes.addAll(e.collect { i -> i.toString() })
+    }
+
+    public void quiet(boolean value) {
+        quiet = value
+    }
+
+    public boolean isQuiet() {
+        return quiet
     }
 
     public void jvmArgs(String... args) {

--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPlugin.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaPlugin.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.plugins.JavaPlugin
 
 @CompileStatic
 public class RetrolambdaPlugin implements Plugin<Project> {
-    protected static String retrolambdaCompile = "net.orfjackal.retrolambda:retrolambda:2.3.0"
+    protected static String retrolambdaCompile = "net.orfjackal.retrolambda:retrolambda:2.4.0"
 
     @Override
     void apply(Project project) {

--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaTask.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaTask.groovy
@@ -50,6 +50,9 @@ class RetrolambdaTask extends DefaultTask {
     @Input
     List<String> jvmArgs = []
 
+    @Input
+    boolean quiet
+
     @TaskAction
     def execute(IncrementalTaskInputs inputs) {
         def retrolambda = project.extensions.getByType(RetrolambdaExtension)
@@ -79,6 +82,7 @@ class RetrolambdaTask extends DefaultTask {
             }
             exec.defaultMethods = retrolambda.defaultMethods
             exec.jvmArgs = jvmArgs
+            exec.quiet = quiet && retrolambda.quiet
             exec.exec()
         }
 

--- a/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaTransform.groovy
+++ b/gradle-retrolambda/src/main/groovy/me/tatarka/RetrolambdaTransform.groovy
@@ -87,6 +87,7 @@ class RetrolambdaTransform extends Transform {
                 exec.includedFiles = changed
                 exec.defaultMethods = retrolambda.defaultMethods
                 exec.jvmArgs = retrolambda.jvmArgs
+                exec.quiet = retrolambda.quiet
                 exec.exec()
             }
         }
@@ -171,6 +172,7 @@ class RetrolambdaTransform extends Transform {
                 .put("incremental", retrolambda.incremental)
                 .put("defaultMethods", retrolambda.defaultMethods)
                 .put("jdk", retrolambda.tryGetJdk())
+                .put("quiet", retrolambda.quiet)
                 .build();
     }
 

--- a/gradle-retrolambda/src/test/java/me/tatarka/AndroidAppPluginTest.java
+++ b/gradle-retrolambda/src/test/java/me/tatarka/AndroidAppPluginTest.java
@@ -75,12 +75,12 @@ public class AndroidAppPluginTest {
                         "}\n" +
                         "\n" +
                         "android {\n" +
-                        "    compileSdkVersion 24\n" +
-                        "    buildToolsVersion '24.0.2'\n" +
+                        "    compileSdkVersion 25\n" +
+                        "    buildToolsVersion '25.0.2'\n" +
                         "    \n" +
                         "    defaultConfig {\n" +
                         "        minSdkVersion 15\n" +
-                        "        targetSdkVersion 24\n" +
+                        "        targetSdkVersion 25\n" +
                         "    }\n" +
                         "}");
 
@@ -145,12 +145,12 @@ public class AndroidAppPluginTest {
                         "}\n" +
                         "\n" +
                         "android {\n" +
-                        "    compileSdkVersion 24\n" +
-                        "    buildToolsVersion '24.0.2'\n" +
+                        "    compileSdkVersion 25\n" +
+                        "    buildToolsVersion '25.0.2'\n" +
                         "    \n" +
                         "    defaultConfig {\n" +
                         "        minSdkVersion 15\n" +
-                        "        targetSdkVersion 24\n" +
+                        "        targetSdkVersion 25\n" +
                         "    }\n" +
                         "}");
 
@@ -236,12 +236,12 @@ public class AndroidAppPluginTest {
                         "}\n" +
                         "\n" +
                         "android {\n" +
-                        "    compileSdkVersion 24\n" +
-                        "    buildToolsVersion '24.0.2'\n" +
+                        "    compileSdkVersion 25\n" +
+                        "    buildToolsVersion '25.0.2'\n" +
                         "    \n" +
                         "    defaultConfig {\n" +
                         "        minSdkVersion 15\n" +
-                        "        targetSdkVersion 24\n" +
+                        "        targetSdkVersion 25\n" +
                         "    }\n" +
                         "}\n" +
                         "\n" +
@@ -319,12 +319,12 @@ public class AndroidAppPluginTest {
                         "}\n" +
                         "\n" +
                         "android {\n" +
-                        "    compileSdkVersion 23\n" +
-                        "    buildToolsVersion '24.0.2'\n" +
+                        "    compileSdkVersion 25\n" +
+                        "    buildToolsVersion '25.0.2'\n" +
                         "    \n" +
                         "    defaultConfig {\n" +
                         "        minSdkVersion 15\n" +
-                        "        targetSdkVersion 24\n" +
+                        "        targetSdkVersion 25\n" +
                         "        testInstrumentationRunner \"android.support.test.runner.AndroidJUnitRunner\"\n" +
                         "    }\n" +
                         "}\n" +
@@ -406,12 +406,12 @@ public class AndroidAppPluginTest {
                         "}\n" +
                         "\n" +
                         "android {\n" +
-                        "    compileSdkVersion 24\n" +
-                        "    buildToolsVersion '24.0.2'\n" +
+                        "    compileSdkVersion 25\n" +
+                        "    buildToolsVersion '25.0.2'\n" +
                         "    \n" +
                         "    defaultConfig {\n" +
                         "        minSdkVersion 15\n" +
-                        "        targetSdkVersion 24\n" +
+                        "        targetSdkVersion 25\n" +
                         "    }\n" +
                         "}\n" +
                         "dependencies {\n" +

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = me.tatarka
 version = 3.4.0
-androidPluginVersion = 2.2.2
+androidPluginVersion = 2.3.0-beta2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/sample-android-app/build.gradle
+++ b/sample-android-app/build.gradle
@@ -28,9 +28,9 @@ dependencies {
     apt "com.google.dagger:dagger-compiler:2.6"
     provided 'javax.annotation:jsr250-api:1.0'
 
-    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:25.1.0'
 
-    androidTestCompile 'com.android.support:support-annotations:24.2.0'
+    androidTestCompile 'com.android.support:support-annotations:25.1.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
@@ -42,13 +42,13 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "me.tatarka.retrolambda.sample.app"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/sample-android-lib/build.gradle
+++ b/sample-android-lib/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'me.tatarka.retrolambda'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -44,5 +44,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:24.2.0'
+    compile 'com.android.support:support-annotations:25.1.0'
 }

--- a/sample-android-test/build.gradle
+++ b/sample-android-test/build.gradle
@@ -20,12 +20,12 @@ apply plugin: 'com.android.test'
 apply plugin: 'me.tatarka.retrolambda'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
 
         testApplicationId 'me.tatarka.retrolambda.sample.test'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
@@ -45,7 +45,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:24.2.0'
+    compile 'com.android.support:support-annotations:25.1.0'
     compile 'com.android.support.test:runner:0.5'
     compile 'com.android.support.test:rules:0.5'
     compile 'com.android.support.test.espresso:espresso-core:2.2.2'


### PR DESCRIPTION
This PR adds a new Configuration setting, mapped to the new "quiet" parameter added in Retrolambda 2.4.0 (https://github.com/orfjackal/retrolambda/issues/103).